### PR TITLE
Issue #2 Fail when copy data exceeds defined max-size

### DIFF
--- a/commands/copy.go
+++ b/commands/copy.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -41,7 +42,7 @@ func NewCopyCommand(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().DurationVar(&r.timeout, "timeout", 5*time.Second, "Time limit for requests")
 	cmd.Flags().StringVarP(&r.password, "password", "p", "", "Password for encryption/decryption")
 	cmd.Flags().StringVarP(&r.basicAuth, "basic-auth", "a", "", "Basic authentication, username:password")
-	cmd.Flags().IntVar(&r.maxBufSize, "maxSize", 500, "Max data size in MB")
+	cmd.Flags().IntVar(&r.maxBufSize, "max-size", 500, "Max data size in MB")
 	return cmd
 }
 
@@ -90,15 +91,15 @@ func (r *copyRunner) run(_ *cobra.Command, _ []string) error {
 }
 
 // readNoMoreThan reads at most, max bytes from reader.
-//It returns an error if there is more data to be read.
+// It returns an error if there is more data to be read.
 func readNoMoreThan(r io.Reader, max int) ([]byte, error) {
-	//try to read 1byte more than the max
+	// try to read 1byte more than the max
 	data := make([]byte, max+1)
 	_, err := io.ReadFull(r, data)
 	if err == nil {
 		return nil, fmt.Errorf("data size exceeds %dBytes", max)
 	}
-	if err != io.ErrUnexpectedEOF {
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, err
 	}
 	return data, nil

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -98,7 +98,6 @@ func (r *copyRunner) run(_ *cobra.Command, _ []string) error {
 // It returns an error if there is more data to be read.
 func readNoMoreThan(r io.Reader, max int64) ([]byte, error) {
 	var data bytes.Buffer
-	// try to read one byte more than the max
 	n, err := data.ReadFrom(io.LimitReader(r, max+1))
 	if err != nil {
 		return nil, err

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -104,7 +104,7 @@ func readNoMoreThan(r io.Reader, max int64) ([]byte, error) {
 		return nil, err
 	}
 	if n > max {
-		return data.Bytes(), fmt.Errorf("input data exceeds set limit %dBytes", max)
+		return nil, fmt.Errorf("input data exceeds set limit %dBytes", max)
 	}
 	return data.Bytes(), nil
 }

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -112,8 +112,7 @@ func readNoMoreThan(r io.Reader, max int64) ([]byte, error) {
 // datasizeToBytes converts a datasize to its equivalent in bytes.
 func datasizeToBytes(ds string) (int64, error) {
 	var maxBufSizeBytes datasize.ByteSize
-	err := maxBufSizeBytes.UnmarshalText([]byte(ds))
-	if err != nil {
+	if err := maxBufSizeBytes.UnmarshalText([]byte(ds)); err != nil {
 		return 0, errors.Unwrap(err)
 	}
 	return int64(maxBufSizeBytes.Bytes()), nil

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/c2h5oh/datasize"
 	"github.com/spf13/cobra"
 
 	pbcrypto "github.com/nakabonne/pbgopy/crypto"
@@ -21,7 +22,7 @@ type copyRunner struct {
 	timeout    time.Duration
 	password   string
 	basicAuth  string
-	maxBufSize int
+	maxBufSize string
 
 	stdout io.Writer
 	stderr io.Writer
@@ -42,7 +43,7 @@ func NewCopyCommand(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().DurationVar(&r.timeout, "timeout", 5*time.Second, "Time limit for requests")
 	cmd.Flags().StringVarP(&r.password, "password", "p", "", "Password for encryption/decryption")
 	cmd.Flags().StringVarP(&r.basicAuth, "basic-auth", "a", "", "Basic authentication, username:password")
-	cmd.Flags().IntVar(&r.maxBufSize, "max-size", 500, "Max data size in MB")
+	cmd.Flags().StringVar(&r.maxBufSize, "max-size", "500mb", "Max data size with unit")
 	return cmd
 }
 
@@ -52,8 +53,11 @@ func (r *copyRunner) run(_ *cobra.Command, _ []string) error {
 		return fmt.Errorf("put the pbgopy server's address into %s environment variable", pbgopyServerEnv)
 	}
 
-	maxBufSizeBytes := r.maxBufSize * 1024 * 1024
-	data, err := readNoMoreThan(os.Stdin, maxBufSizeBytes)
+	sizeInBytes, err := datasizeToBytes(r.maxBufSize)
+	if err != nil {
+		return fmt.Errorf("failed to parse data size: %w", err)
+	}
+	data, err := readNoMoreThan(os.Stdin, sizeInBytes)
 	if err != nil {
 		return fmt.Errorf("failed to read from STDIN: %w", err)
 	}
@@ -92,17 +96,32 @@ func (r *copyRunner) run(_ *cobra.Command, _ []string) error {
 
 // readNoMoreThan reads at most, max bytes from reader.
 // It returns an error if there is more data to be read.
-func readNoMoreThan(r io.Reader, max int) ([]byte, error) {
+func readNoMoreThan(r io.Reader, max uint64) ([]byte, error) {
 	// try to read 1byte more than the max
 	data := make([]byte, max+1)
 	_, err := io.ReadFull(r, data)
 	if err == nil {
-		return nil, fmt.Errorf("data size exceeds %dBytes", max)
+		return nil, fmt.Errorf("input data exceeds limit %s", bytesToDatasize(max))
 	}
 	if !errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil, err
 	}
 	return data, nil
+}
+
+// datasizeToBytes converts a datasize to its equivalent in bytes.
+func datasizeToBytes(ds string) (uint64, error) {
+	var maxBufSizeBytes datasize.ByteSize
+	err := maxBufSizeBytes.UnmarshalText([]byte(ds))
+	if err != nil {
+		return 0, errors.Unwrap(err)
+	}
+	return maxBufSizeBytes.Bytes(), nil
+}
+
+// bytesToDatasize converts bytes to a human-readable datasize
+func bytesToDatasize(b uint64) string {
+	return datasize.ByteSize(b).HumanReadable()
 }
 
 // regenerateSalt lets the server regenerate the salt and gives back the new one.

--- a/commands/copy_test.go
+++ b/commands/copy_test.go
@@ -87,6 +87,10 @@ func TestDatasizeToBytes(t *testing.T) {
 			datasize: "-4mb",
 			err:      errInvalidSyntax,
 		},
+		{
+			datasize: "1.1kb",
+			err:      errInvalidSyntax,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/commands/copy_test.go
+++ b/commands/copy_test.go
@@ -1,1 +1,97 @@
 package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadNoMoreThan(t *testing.T) {
+	value := []byte("Foo Bar Baz")
+
+	testCases := []struct {
+		name   string
+		reader io.Reader
+		max    int64
+		err    error
+		value  []byte
+	}{
+		{
+			name:   "TestExactLength",
+			reader: bytes.NewReader(value),
+			max:    11,
+			value:  value,
+		},
+		{
+			name:   "TestShortData",
+			reader: bytes.NewReader(value),
+			max:    20,
+			value:  value,
+		},
+		{
+			name:   "TestTooMuchData",
+			reader: bytes.NewReader(value),
+			max:    6,
+			err:    fmt.Errorf("input data exceeds set limit 6Bytes"),
+		},
+		{
+			name:   "TestNoData",
+			reader: strings.NewReader(""),
+			max:    6,
+			value:  []byte(""),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			value, err := readNoMoreThan(tc.reader, tc.max)
+			assert.Equal(t, tc.err, err)
+			assert.Equal(t, tc.value, value)
+		})
+	}
+}
+
+func TestDatasizeToBytes(t *testing.T) {
+	errInvalidSyntax := fmt.Errorf("invalid syntax")
+
+	testCases := []struct {
+		datasize    string
+		err         error
+		sizeInBytes int64
+	}{
+		{
+			datasize:    "1B",
+			sizeInBytes: 1,
+		},
+		{
+			datasize:    "1000kb",
+			sizeInBytes: 1000 * 1024,
+		},
+		{
+			datasize:    "12mb",
+			sizeInBytes: 12 * 1024 * 1024,
+		},
+		{
+			datasize:    "1megabyte",
+			sizeInBytes: 1 * 1024 * 1024,
+		},
+		{
+			datasize: "1meg",
+			err:      errInvalidSyntax,
+		},
+		{
+			datasize: "-4mb",
+			err:      errInvalidSyntax,
+		},
+	}
+
+	for _, tc := range testCases {
+		sizeInBytes, err := datasizeToBytes(tc.datasize)
+		assert.Equal(t, tc.err, err)
+		assert.Equal(t, tc.sizeInBytes, sizeInBytes)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nakabonne/pbgopy
 go 1.15
 
 require (
+	github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2 h1:t8KYCwSKsOEZBFELI4Pn/phbp38iJ1RRAkDFNin1aak=
+github.com/c2h5oh/datasize v0.0.0-20200825124411-48ed595a09d2/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=


### PR DESCRIPTION
 * Register a max-buffer-size flag in copy command which defaults to 500MB
 * Fail with an error when data to be copied exceeds the maximum buffer size set using the maxSize flag