### PR TITLE
Issue #4 - Stop using an empty nonce for GCM

### DIFF
--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -3,10 +3,10 @@ package crypto
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
-	"math/rand"
-	"time"
+	"io"
 
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -27,8 +27,11 @@ func Encrypt(password string, salt, data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	nonce := make([]byte, gcm.NonceSize())
-	// TODO: Stop using an empty nonce for GCM
+	nonce, err := GetNonce(gcm.NonceSize())
+	if err != nil {
+		return nil, err
+	}
+
 	encryptedData := gcm.Seal(nonce, nonce, data, nil)
 	return encryptedData, nil
 }
@@ -54,16 +57,13 @@ func Decrypt(password string, salt, encryptedData []byte) ([]byte, error) {
 	return gcm.Open(nil, nonce, ciphertext, nil)
 }
 
-const charset = "abcdefghijklmnopqrstuvwxyz" +
-	"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+func GetNonce(length int) ([]byte, error) {
+	nonce := make([]byte, length)
 
-var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-// RandomBytes yields a random bytes with the given length.
-func RandomBytes(length int) []byte {
-	b := make([]byte, length)
-	for i := range b {
-		b[i] = charset[seededRand.Intn(len(charset))]
+	_, err := io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return nil, err
 	}
-	return b
+
+	return nonce, nil
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -3,10 +3,12 @@ package crypto
 import (
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/rand"
+	cryrand "crypto/rand"
 	"crypto/sha256"
 	"fmt"
 	"io"
+	"math/rand"
+	"time"
 
 	"golang.org/x/crypto/pbkdf2"
 )
@@ -57,10 +59,24 @@ func Decrypt(password string, salt, encryptedData []byte) ([]byte, error) {
 	return gcm.Open(nil, nonce, ciphertext, nil)
 }
 
+const charset = "abcdefghijklmnopqrstuvwxyz" +
+	"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// RandomBytes yields a random bytes with the given length.
+func RandomBytes(length int) []byte {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return b
+}
+
 func GetNonce(length int) ([]byte, error) {
 	nonce := make([]byte, length)
 
-	_, err := io.ReadFull(rand.Reader, nonce)
+	_, err := io.ReadFull(cryrand.Reader, nonce)
 	if err != nil {
 		return nil, err
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -29,7 +29,7 @@ func Encrypt(password string, salt, data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	nonce, err := GetNonce(gcm.NonceSize())
+	nonce, err := getNonce(gcm.NonceSize())
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func RandomBytes(length int) []byte {
 	return b
 }
 
-func GetNonce(length int) ([]byte, error) {
+func getNonce(length int) ([]byte, error) {
 	nonce := make([]byte, length)
 
 	_, err := io.ReadFull(cryrand.Reader, nonce)

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -1,7 +1,6 @@
 package crypto
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,26 +44,4 @@ func TestEncryptDecrypt(t *testing.T) {
 			assert.Equal(t, tt.wantSuccess, string(data) == string(plainText))
 		})
 	}
-}
-
-func TestRandomBytes(t *testing.T) {
-	validator := func(bs []byte) error {
-		for _, b := range bs {
-			if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') {
-				continue
-			}
-			return fmt.Errorf("invalid character: %#U", b)
-		}
-		return nil
-	}
-
-	s1 := RandomBytes(10)
-	assert.Equal(t, 10, len(s1))
-	assert.NoError(t, validator(s1))
-
-	s2 := RandomBytes(10)
-	assert.Equal(t, 10, len(s2))
-	assert.NoError(t, validator(s2))
-
-	assert.NotEqual(t, s1, s2)
 }

--- a/crypto/crypto_test.go
+++ b/crypto/crypto_test.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,4 +45,26 @@ func TestEncryptDecrypt(t *testing.T) {
 			assert.Equal(t, tt.wantSuccess, string(data) == string(plainText))
 		})
 	}
+}
+
+func TestRandomBytes(t *testing.T) {
+	validator := func(bs []byte) error {
+		for _, b := range bs {
+			if (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') {
+				continue
+			}
+			return fmt.Errorf("invalid character: %#U", b)
+		}
+		return nil
+	}
+
+	s1 := RandomBytes(10)
+	assert.Equal(t, 10, len(s1))
+	assert.NoError(t, validator(s1))
+
+	s2 := RandomBytes(10)
+	assert.Equal(t, 10, len(s2))
+	assert.NoError(t, validator(s2))
+
+	assert.NotEqual(t, s1, s2)
 }


### PR DESCRIPTION
In crypto/crypto.go
  Used crypto/rand to supply secure random data to fill the nonce
  Created func GetNonce to contain logic for generating the nonce
   given the nonce size
  Removed unused function RandomBytes. The functionality provided
   is simple to replicate if needed in the future. So for now, I'd
   just rather remove the cognative load of just having that there.

In crypto/crypto_test.go
  Removed tests for RandomBytes