### PR TITLE
Feat/lastupdated

### DIFF
--- a/commands/serve.go
+++ b/commands/serve.go
@@ -20,11 +20,13 @@ const (
 	defaultPort = 9090
 	defaultTTL  = time.Hour * 24
 
-	rootPath = "/"
-	saltPath = "/salt"
+	rootPath        = "/"
+	saltPath        = "/salt"
+	lastUpdatedPath = "/lastupdated"
 
-	dataKey = "data"
-	saltKey = "salt"
+	dataKey        = "data"
+	saltKey        = "salt"
+	lastUpdatedKey = "lastUpdated"
 )
 
 type serveRunner struct {
@@ -92,7 +94,14 @@ func (r *serveRunner) createServer() *http.Server {
 	}
 	mux.HandleFunc(rootPath, r.basicAuthHandler(r.handle))
 	mux.HandleFunc(saltPath, r.basicAuthHandler(r.handleSalt))
+	mux.HandleFunc(lastUpdatedPath, r.handleLastUpdated)
 	return server
+}
+
+func (r *serveRunner) handleLastUpdated(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+
+	}
 }
 
 func (r *serveRunner) handle(w http.ResponseWriter, req *http.Request) {

--- a/commands/serve.go
+++ b/commands/serve.go
@@ -100,7 +100,19 @@ func (r *serveRunner) createServer() *http.Server {
 
 func (r *serveRunner) handleLastUpdated(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
-
+	case http.MethodGet:
+		lastUpdated, err := r.cache.Get(lastUpdatedKey)
+		if err != nil {
+			http.Error(w, "Failed to get lastUpdated timestamp from cache", http.StatusInternalServerError)
+			return
+		}
+		if lu, ok := lastUpdated.(int64); ok {
+			fmt.Fprintf(w, "%d", lu)
+			return
+		}
+		http.Error(w, fmt.Sprintf("The lastUpdated timestamp is unknown type: %T", lastUpdated), http.StatusInternalServerError)
+	default:
+		http.Error(w, fmt.Sprintf("Method %s is not allowed", req.Method), http.StatusMethodNotAllowed)
 	}
 }
 

--- a/commands/serve.go
+++ b/commands/serve.go
@@ -140,6 +140,10 @@ func (r *serveRunner) handle(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, fmt.Sprintf("Failed to cache: %v", err), http.StatusInternalServerError)
 			return
 		}
+		if err := r.cache.Put(lastUpdatedKey, time.Now().UnixNano()); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to save lastUpdated timestamp: %v", err), http.StatusInternalServerError)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	default:
 		http.Error(w, fmt.Sprintf("Method %s is not allowed", req.Method), http.StatusMethodNotAllowed)


### PR DESCRIPTION
This PR is useful to extensions such as [pbgopy-clip](https://github.com/thealamu/pbgopy-clip).
Currently, the only way to tell if the server has new data is to compare the content at a time byte by byte with content at another time.
This PR exposes a 'lastUpdated' endpoint for programs that want to sync data using pbgopy. It fits into the codebase well enough and has tests passing, but if you need to see it in action, I merged this PR on my [pbgopy-diverge](https://github.com/thealamu/pbgopy/tree/pbgopy-diverge) branch.