### PR TITLE
Add Nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ AUR package is available: [pbgopy](https://aur.archlinux.org/packages/pbgopy/)
 yay pbgopy
 ```
 
+#### Nix
+
+```
+nix-shell -p nixpkgs.pbgopy
+```
+
 #### Go
 
 ```


### PR DESCRIPTION
I've recently packaged pbgopy for Nix, and i thought it might be nice if this were discoverable from the readme.