### PR TITLE
Fix CI: update Go versions and golangci-lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,11 +10,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.33
+          go-version: '1.22'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
           args: --issues-exit-code=0
           only-new-issues: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,16 +14,16 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.21.x, 1.22.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build
       run: go build
     - name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,17 @@
 module github.com/nakabonne/pbgopy
 
-go 1.16
+go 1.21
 
 require (
 	github.com/atotto/clipboard v0.1.2
 	github.com/spf13/cobra v1.1.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 )


### PR DESCRIPTION
## Summary

- **test.yaml**: Go 1.14.x/1.15.x are no longer available on arm64 macOS runners. Updated to Go 1.21/1.22 with `actions/setup-go@v5` and `actions/checkout@v4`
- **lint.yaml**: golangci-lint v1.33 cannot parse export data from modern Go versions (version skew error). Updated to v1.59 with `golangci-lint-action@v6` and explicit Go 1.22 setup

## Test plan

- [ ] Verify lint job passes on this PR
- [ ] Verify test matrix (Go 1.21 + 1.22, ubuntu + macOS) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)