### PR TITLE
Add clipboard history support

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,7 +51,5 @@ linters-settings:
     min-occurrences: 2
   goimports:
     local-prefixes: github.com/nakabonne/pbgopy
-  maligned:
-    suggest-new: true
   misspell:
     locale: US

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,5 +1,6 @@
 run:
   issues-exit-code: 0
+  tests: false
 
 linters:
   disable-all: true
@@ -12,12 +13,9 @@ linters:
     - unparam
     - gofmt
     - goimports
-    - deadcode
     - nestif
     - govet
-    - golint
     - prealloc
-    - depguard
     - dogsled
     - dupl
     - goconst
@@ -27,26 +25,20 @@ linters:
     - gosec
     - nakedret
     - rowserrcheck
-    - scopelint
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
-    - varcheck
     - exhaustive
     - exportloopref
-    - goerr113
+    - err113
     - gofumpt
     - unused
-
-run:
-  tests: false
 
 issues:
   exclude-rules:
     - linters:
-      - goerr113
-      text: "err113: do not define dynamic errors"
+      - err113
+      text: "do not define dynamic errors"
 
 linters-settings:
   dupl:
@@ -59,8 +51,6 @@ linters-settings:
     min-occurrences: 2
   goimports:
     local-prefixes: github.com/nakabonne/pbgopy
-  golint:
-    min-confidence: 0.3
   maligned:
     suggest-new: true
   misspell:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ export PBGOPY_SERVER=http://host.xz:9090
 pbgopy paste >foo.png
 ```
 
+To keep previous copies, start the server with a larger history limit:
+
+```bash
+pbgopy serve --history-limit 20
+```
+
+Each successful `copy` creates a new history entry and `paste` still returns the latest entry by default. You can list entries without printing full clipboard contents, paste a specific entry, or delete history:
+
+```bash
+pbgopy history
+pbgopy history --json
+pbgopy paste --id <entry-id> >foo.png
+pbgopy history delete <entry-id>
+pbgopy history clear
+```
+
+The default history limit is `1`, which preserves the existing latest-only behavior. Give `--history-limit 0` for unlimited in-memory history.
 
 ## End-to-end encryption
 `pbgopy` comes with a built-in ability to encrypt/decrypt with a variety of keys.
@@ -131,6 +148,7 @@ There are a couple of ways to specify a user ID. Visit [here](https://www.gnupg.
 
 ## TTL
 If you don't want more data to be cached on the server than necessary, use the `--ttl` flag to set TTL for the cache.
+TTL applies to each history entry, and expired entries are not listed or pasteable.
 Give `0s` for disabling it. Default is `24h`.
 
 ```bash
@@ -197,18 +215,47 @@ Usage:
 Examples:
   export PBGOPY_SERVER=http://host.xz:9090
   pbgopy paste >hello.txt
+  pbgopy paste --id <entry-id> >hello.txt
 
 Flags:
   -a, --basic-auth string                  Basic authentication, username:password
       --gpg-path string                    Path to gpg executable (default "gpg")
   -u, --gpg-user-id string                 GPG user id associated with private-key to be used for decryption
   -h, --help                               help for paste
+      --id string                          History entry id to paste
       --max-size string                    Max data size with unit (default "500mb")
   -p, --password string                    Password to derive the symmetric-key to be used for decryption
   -K, --private-key-file string            Path to an RSA private-key file to be used for decryption; Must be in PEM or DER format
       --private-key-password-file string   Path to password file to decrypt the encrypted private key
   -k, --symmetric-key-file string          Path to symmetric-key file to be used for decryption
       --timeout duration                   Time limit for requests (default 5s)
+```
+
+#### History
+```
+pbgopy history -h
+List clipboard history
+
+Usage:
+  pbgopy history [flags]
+  pbgopy history [command]
+
+Available Commands:
+  clear       Delete all history entries
+  delete      Delete a history entry
+
+Examples:
+  export PBGOPY_SERVER=http://host.xz:9090
+  pbgopy history
+  pbgopy history --json
+  pbgopy history delete <entry-id>
+  pbgopy history clear
+
+Flags:
+  -a, --basic-auth string   Basic authentication, username:password
+  -h, --help                help for history
+      --json                Output history metadata as JSON
+      --timeout duration    Time limit for requests (default 5s)
 ```
 
 #### Serve
@@ -220,13 +267,14 @@ Usage:
   pbgopy serve [flags]
 
 Examples:
-pbgopy serve --port=9090 --ttl=10m
+pbgopy serve --port=9090 --ttl=10m --history-limit=20
 
 Flags:
-  -a, --basic-auth string   Basic authentication, username:password
-  -h, --help                help for serve
-  -p, --port int            The port the server listens on (default 9090)
-      --ttl duration        The time that the contents is stored. Give 0s for disabling TTL (default 24h0m0s)
+  -a, --basic-auth string     Basic authentication, username:password
+  -h, --help                  help for serve
+      --history-limit int     Number of clipboard entries to retain. Give 0 for unlimited history (default 1)
+  -p, --port int              The port the server listens on (default 9090)
+      --ttl duration          The time that the contents is stored. Give 0s for disabling TTL (default 24h0m0s)
 ```
 
 ## Inspired By

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ export PBGOPY_SERVER=http://host.xz:9090
 pbgopy paste >foo.png
 ```
 
+## History of copies
+
 To keep previous copies, start the server with a larger history limit:
 
 ```bash
@@ -85,11 +87,12 @@ pbgopy serve --history-limit 20
 Each successful `copy` creates a new history entry and `paste` still returns the latest entry by default. You can list entries without printing full clipboard contents, paste a specific entry, or delete history:
 
 ```bash
-pbgopy history
-pbgopy history --json
-pbgopy paste --id <entry-id> >foo.png
-pbgopy history delete <entry-id>
-pbgopy history clear
+$ pbgopy history
+ID                                AGE  TYPE                       SIZE   LATEST  PREVIEW
+fcd0bc9afd9586c4544c377024d4e3b1  4s   text/plain; charset=utf-8  6B     *       "world"
+f9db4d7b8befb5d8b86b39e58b695126  9m   image/jpeg                 1.6MB          JPEG image 3144x4192
+
+$ pbgopy paste --id f9db4d7b8befb5d8b86b39e58b695126 >foo.jpg
 ```
 
 The default history limit is `1`, which preserves the existing latest-only behavior. Give `--history-limit 0` for unlimited in-memory history.

--- a/commands/common.go
+++ b/commands/common.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 
 	pbcrypto "github.com/nakabonne/pbgopy/crypto"
 	"github.com/nakabonne/pbgopy/datasize"
@@ -35,6 +37,23 @@ func addBasicAuthHeader(req *http.Request, basicAuth string) {
 		return
 	}
 	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(basicAuth)))
+}
+
+func historyEntryURL(address, id string) string {
+	return strings.TrimRight(address, "/") + historyPath + "/" + url.PathEscape(id)
+}
+
+func historyURL(address string) string {
+	return strings.TrimRight(address, "/") + historyPath
+}
+
+func failedRequestError(res *http.Response) error {
+	body, _ := ioutil.ReadAll(io.LimitReader(res.Body, 4096))
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		return fmt.Errorf("failed request: Status %s", res.Status)
+	}
+	return fmt.Errorf("failed request: Status %s: %s", res.Status, msg)
 }
 
 // readNoMoreThan reads at most, max bytes from reader.

--- a/commands/copy.go
+++ b/commands/copy.go
@@ -84,7 +84,8 @@ func (r *copyRunner) run(_ *cobra.Command, _ []string) error {
 	}
 
 	// Start encryption.
-	data, err = r.encrypt(data)
+	var encrypted bool
+	data, encrypted, err = r.encrypt(data)
 	if err != nil {
 		return err
 	}
@@ -96,6 +97,9 @@ func (r *copyRunner) run(_ *cobra.Command, _ []string) error {
 	req, err := http.NewRequest(http.MethodPut, address, bytes.NewBuffer(data))
 	if err != nil {
 		return fmt.Errorf("failed to make request: %w", err)
+	}
+	if encrypted {
+		req.Header.Set(historyEncryptedHeader, "true")
 	}
 	addBasicAuthHeader(req, r.basicAuth)
 	res, err := client.Do(req)
@@ -111,29 +115,30 @@ func (r *copyRunner) run(_ *cobra.Command, _ []string) error {
 }
 
 // encrypts with the user-specified way. It directly gives back plaintext if any key doesn't exists.
-func (r *copyRunner) encrypt(plaintext []byte) ([]byte, error) {
+func (r *copyRunner) encrypt(plaintext []byte) ([]byte, bool, error) {
 	if (r.password != "" || r.symmetricKeyFile != "") && (r.publicKeyFile != "" || r.gpgUserID != "") {
-		return nil, fmt.Errorf("only one of the symmetric-key or public-key can be used for encryption")
+		return nil, false, fmt.Errorf("only one of the symmetric-key or public-key can be used for encryption")
 	}
 
 	// Perform hybrid encryption with a public-key if it exists.
 	if r.publicKeyFile != "" || r.gpgUserID != "" {
-		return r.encryptWithPubKey(plaintext)
+		data, err := r.encryptWithPubKey(plaintext)
+		return data, true, err
 	}
 
 	// Encrypt with a symmetric-key if key exists.
 	key, err := getSymmetricKey(r.password, r.symmetricKeyFile)
 	if errors.Is(err, errNotfound) {
-		return plaintext, nil
+		return plaintext, false, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to get key: %w", err)
+		return nil, false, fmt.Errorf("failed to get key: %w", err)
 	}
 	encrypted, err := pbcrypto.Encrypt(key, plaintext)
 	if err != nil {
-		return nil, fmt.Errorf("failed to encrypt the plaintext: %w", err)
+		return nil, false, fmt.Errorf("failed to encrypt the plaintext: %w", err)
 	}
-	return encrypted, nil
+	return encrypted, true, nil
 }
 
 // NOTE: pbgopy provides two way to specify the public key. Specifying path directly or specifying via GPG.

--- a/commands/history.go
+++ b/commands/history.go
@@ -206,7 +206,7 @@ func formatHistorySize(size int) string {
 	value := float64(size)
 	unit := 0
 	for value >= 1024 && unit < len(units)-1 {
-		value = value / 1024
+		value /= 1024
 		unit++
 	}
 	if unit == 0 {

--- a/commands/history.go
+++ b/commands/history.go
@@ -1,0 +1,216 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type historyRunner struct {
+	timeout    time.Duration
+	basicAuth  string
+	jsonOutput bool
+
+	stdout io.Writer
+	stderr io.Writer
+	client *http.Client
+}
+
+func NewHistoryCommand(stdout, stderr io.Writer) *cobra.Command {
+	r := &historyRunner{
+		stdout: stdout,
+		stderr: stderr,
+	}
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "List clipboard history",
+		Example: `  export PBGOPY_SERVER=http://host.xz:9090
+  pbgopy history
+  pbgopy history --json
+  pbgopy history delete <entry-id>
+  pbgopy history clear`,
+		RunE: r.list,
+	}
+	cmd.PersistentFlags().DurationVar(&r.timeout, "timeout", 5*time.Second, "Time limit for requests")
+	cmd.PersistentFlags().StringVarP(&r.basicAuth, "basic-auth", "a", "", "Basic authentication, username:password")
+	cmd.Flags().BoolVar(&r.jsonOutput, "json", false, "Output history metadata as JSON")
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "delete <entry-id>",
+		Short: "Delete a history entry",
+		Args:  cobra.ExactArgs(1),
+		RunE:  r.delete,
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "clear",
+		Short: "Delete all history entries",
+		Args:  cobra.NoArgs,
+		RunE:  r.clear,
+	})
+	return cmd
+}
+
+func (r *historyRunner) list(_ *cobra.Command, _ []string) error {
+	address := os.Getenv(pbgopyServerEnv)
+	if address == "" {
+		return fmt.Errorf("put the pbgopy server's address into %s environment variable", pbgopyServerEnv)
+	}
+
+	res, err := r.do(http.MethodGet, historyURL(address))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return failedRequestError(res)
+	}
+
+	var entries []HistoryEntry
+	if err := json.NewDecoder(res.Body).Decode(&entries); err != nil {
+		return fmt.Errorf("failed to decode history: %w", err)
+	}
+
+	if r.jsonOutput {
+		enc := json.NewEncoder(r.stdout)
+		return enc.Encode(entries)
+	}
+	return writeHistoryTable(r.stdout, entries, time.Now())
+}
+
+func (r *historyRunner) delete(_ *cobra.Command, args []string) error {
+	address := os.Getenv(pbgopyServerEnv)
+	if address == "" {
+		return fmt.Errorf("put the pbgopy server's address into %s environment variable", pbgopyServerEnv)
+	}
+
+	res, err := r.do(http.MethodDelete, historyEntryURL(address, args[0]))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+		return failedRequestError(res)
+	}
+	return nil
+}
+
+func (r *historyRunner) clear(_ *cobra.Command, _ []string) error {
+	address := os.Getenv(pbgopyServerEnv)
+	if address == "" {
+		return fmt.Errorf("put the pbgopy server's address into %s environment variable", pbgopyServerEnv)
+	}
+
+	res, err := r.do(http.MethodDelete, historyURL(address))
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+		return failedRequestError(res)
+	}
+	return nil
+}
+
+func (r *historyRunner) do(method, url string) (*http.Response, error) {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request: %w", err)
+	}
+	addBasicAuthHeader(req, r.basicAuth)
+	res, err := r.httpClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to issue request: %w", err)
+	}
+	return res, nil
+}
+
+func (r *historyRunner) httpClient() *http.Client {
+	if r.client != nil {
+		return r.client
+	}
+	return &http.Client{
+		Timeout: r.timeout,
+	}
+}
+
+func writeHistoryTable(w io.Writer, entries []HistoryEntry, now time.Time) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	if _, err := fmt.Fprintln(tw, "ID\tAGE\tTYPE\tSIZE\tLATEST\tPREVIEW"); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		latest := ""
+		if entry.Latest {
+			latest = "*"
+		}
+		preview := entry.Preview
+		if entry.Kind == historyKindText {
+			preview = strconv.Quote(preview)
+		}
+		if _, err := fmt.Fprintf(
+			tw,
+			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			entry.ID,
+			formatHistoryAge(now.Sub(entry.CreatedAt)),
+			historyDisplayType(entry),
+			formatHistorySize(entry.Size),
+			latest,
+			preview,
+		); err != nil {
+			return err
+		}
+	}
+	return tw.Flush()
+}
+
+func historyDisplayType(entry HistoryEntry) string {
+	switch entry.Kind {
+	case historyKindEncrypted, historyKindBinary, historyKindUnknown:
+		return entry.Kind
+	}
+	if entry.MIME != "" {
+		return entry.MIME
+	}
+	if entry.Kind != "" {
+		return entry.Kind
+	}
+	return historyKindUnknown
+}
+
+func formatHistoryAge(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d < time.Minute:
+		return fmt.Sprintf("%ds", int(d/time.Second))
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d/time.Hour))
+	default:
+		return fmt.Sprintf("%dd", int(d/(24*time.Hour)))
+	}
+}
+
+func formatHistorySize(size int) string {
+	units := []string{"B", "KB", "MB", "GB", "TB"}
+	value := float64(size)
+	unit := 0
+	for value >= 1024 && unit < len(units)-1 {
+		value = value / 1024
+		unit++
+	}
+	if unit == 0 {
+		return fmt.Sprintf("%d%s", size, units[unit])
+	}
+	return strings.TrimSuffix(fmt.Sprintf("%.1f", value), ".0") + units[unit]
+}

--- a/commands/history_store.go
+++ b/commands/history_store.go
@@ -1,0 +1,295 @@
+package commands
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	historyKindText      = "text"
+	historyKindImage     = "image"
+	historyKindBinary    = "binary"
+	historyKindEncrypted = "encrypted"
+	historyKindUnknown   = "unknown"
+
+	historyPreviewRunes = 80
+)
+
+// HistoryEntry is the metadata returned by the history API.
+type HistoryEntry struct {
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	Size      int       `json:"size"`
+	Latest    bool      `json:"latest"`
+	MIME      string    `json:"mime"`
+	Kind      string    `json:"kind"`
+	Preview   string    `json:"preview"`
+	SHA256    string    `json:"sha256"`
+}
+
+type historyItem struct {
+	HistoryEntry
+	body      []byte
+	expiresAt time.Time
+}
+
+type historyStore struct {
+	mu        sync.Mutex
+	entries   []*historyItem
+	limit     int
+	ttl       time.Duration
+	everAdded bool
+	now       func() time.Time
+}
+
+func newHistoryStore(limit int, ttl time.Duration) *historyStore {
+	return &historyStore{
+		limit: limit,
+		ttl:   ttl,
+		now:   time.Now,
+	}
+}
+
+func (s *historyStore) Add(body []byte, encrypted bool) (*historyItem, error) {
+	id, err := newHistoryID()
+	if err != nil {
+		return nil, err
+	}
+
+	now := s.now()
+	item := &historyItem{
+		HistoryEntry: newHistoryEntry(id, now, body, encrypted),
+		body:         append([]byte(nil), body...),
+	}
+	if s.ttl > 0 {
+		item.expiresAt = now.Add(s.ttl)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.pruneExpiredLocked(now)
+	s.entries = append([]*historyItem{item}, s.entries...)
+	s.everAdded = true
+	s.enforceLimitLocked()
+	return item.copy(), nil
+}
+
+func (s *historyStore) List() []HistoryEntry {
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.pruneExpiredLocked(now)
+	entries := make([]HistoryEntry, 0, len(s.entries))
+	for i, item := range s.entries {
+		entry := item.HistoryEntry
+		entry.Latest = i == 0
+		entries = append(entries, entry)
+	}
+	return entries
+}
+
+func (s *historyStore) Latest() (*historyItem, bool) {
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.pruneExpiredLocked(now)
+	if len(s.entries) == 0 {
+		return nil, false
+	}
+	item := s.entries[0].copy()
+	item.Latest = true
+	return item, true
+}
+
+func (s *historyStore) Get(id string) (*historyItem, bool) {
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.pruneExpiredLocked(now)
+	for i, item := range s.entries {
+		if item.ID == id {
+			copied := item.copy()
+			copied.Latest = i == 0
+			return copied, true
+		}
+	}
+	return nil, false
+}
+
+func (s *historyStore) Delete(id string) bool {
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.pruneExpiredLocked(now)
+	for i, item := range s.entries {
+		if item.ID == id {
+			s.entries = append(s.entries[:i], s.entries[i+1:]...)
+			return true
+		}
+	}
+	return false
+}
+
+func (s *historyStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.entries = nil
+	s.everAdded = true
+}
+
+func (s *historyStore) EverAdded() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.everAdded
+}
+
+func (s *historyStore) pruneExpiredLocked(now time.Time) {
+	if s.ttl <= 0 {
+		return
+	}
+	n := 0
+	for _, item := range s.entries {
+		if item.expiresAt.IsZero() || item.expiresAt.After(now) {
+			s.entries[n] = item
+			n++
+		}
+	}
+	s.entries = s.entries[:n]
+}
+
+func (s *historyStore) enforceLimitLocked() {
+	if s.limit <= 0 || len(s.entries) <= s.limit {
+		return
+	}
+	s.entries = s.entries[:s.limit]
+}
+
+func (item *historyItem) copy() *historyItem {
+	copied := *item
+	copied.body = append([]byte(nil), item.body...)
+	return &copied
+}
+
+func newHistoryID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("failed to generate history id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func newHistoryEntry(id string, createdAt time.Time, body []byte, encrypted bool) HistoryEntry {
+	sum := sha256.Sum256(body)
+	sha := hex.EncodeToString(sum[:])
+	entry := HistoryEntry{
+		ID:        id,
+		CreatedAt: createdAt,
+		Size:      len(body),
+		MIME:      detectMIME(body),
+		SHA256:    sha,
+	}
+
+	switch {
+	case encrypted:
+		entry.MIME = "application/octet-stream"
+		entry.Kind = historyKindEncrypted
+		entry.Preview = "encrypted sha256:" + sha[:8]
+	case setImageMetadata(&entry, body):
+	case isLikelyText(body):
+		entry.Kind = historyKindText
+		entry.Preview = textPreview(body)
+	case entry.MIME == "":
+		entry.Kind = historyKindUnknown
+		entry.Preview = "unknown sha256:" + sha[:8]
+	default:
+		entry.Kind = historyKindBinary
+		entry.Preview = "binary sha256:" + sha[:8]
+	}
+	return entry
+}
+
+func detectMIME(body []byte) string {
+	sample := body
+	if len(sample) > 512 {
+		sample = sample[:512]
+	}
+	return http.DetectContentType(sample)
+}
+
+func setImageMetadata(entry *HistoryEntry, body []byte) bool {
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(body))
+	if err != nil {
+		return false
+	}
+	entry.Kind = historyKindImage
+	switch format {
+	case "jpeg":
+		entry.MIME = "image/jpeg"
+		entry.Preview = fmt.Sprintf("JPEG image %dx%d", cfg.Width, cfg.Height)
+	case "png":
+		entry.MIME = "image/png"
+		entry.Preview = fmt.Sprintf("PNG image %dx%d", cfg.Width, cfg.Height)
+	case "gif":
+		entry.MIME = "image/gif"
+		entry.Preview = fmt.Sprintf("GIF image %dx%d", cfg.Width, cfg.Height)
+	default:
+		entry.Preview = fmt.Sprintf("%s image %dx%d", strings.ToUpper(format), cfg.Width, cfg.Height)
+	}
+	return true
+}
+
+func isLikelyText(body []byte) bool {
+	if !utf8.Valid(body) {
+		return false
+	}
+	for _, r := range string(body) {
+		if unicode.IsControl(r) && r != '\n' && r != '\r' && r != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
+func textPreview(body []byte) string {
+	var b strings.Builder
+	for _, r := range string(body) {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			b.WriteRune(' ')
+		case unicode.IsControl(r):
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	collapsed := strings.Join(strings.Fields(b.String()), " ")
+	runes := []rune(collapsed)
+	if len(runes) <= historyPreviewRunes {
+		return collapsed
+	}
+	return string(runes[:historyPreviewRunes]) + "..."
+}

--- a/commands/history_test.go
+++ b/commands/history_test.go
@@ -1,0 +1,340 @@
+package commands
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nakabonne/pbgopy/cache/memorycache"
+)
+
+func TestHistoryDefaultLimitPreservesLatestBehavior(t *testing.T) {
+	handler := newHistoryTestHandler(defaultHistoryLimit, 0)
+
+	putClipboard(t, handler, []byte("first"), false)
+	entries := getHistory(t, handler)
+	if len(entries) != 1 {
+		t.Fatalf("history length: got %d want 1", len(entries))
+	}
+	firstID := entries[0].ID
+
+	putClipboard(t, handler, []byte("second"), false)
+	entries = getHistory(t, handler)
+	if len(entries) != 1 {
+		t.Fatalf("history length: got %d want 1", len(entries))
+	}
+	if entries[0].Preview != "second" || !entries[0].Latest {
+		t.Fatalf("latest entry: got %+v", entries[0])
+	}
+
+	rr := serveHistoryRequest(t, handler, http.MethodGet, "/", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET / status: got %d want %d", rr.Code, http.StatusOK)
+	}
+	if got := rr.Body.String(); got != "second" {
+		t.Fatalf("GET / body: got %q want %q", got, "second")
+	}
+
+	rr = serveHistoryRequest(t, handler, http.MethodGet, historyPath+"/"+firstID, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("old entry status: got %d want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHistoryLimitPasteByIDAndBinaryRoundTrip(t *testing.T) {
+	handler := newHistoryTestHandler(3, 0)
+	binary := []byte{0x00, 0xff, 0x10, 0x20, 0x7f}
+
+	putClipboard(t, handler, []byte("first"), false)
+	putClipboard(t, handler, binary, false)
+	putClipboard(t, handler, []byte("third"), false)
+
+	entries := getHistory(t, handler)
+	if len(entries) != 3 {
+		t.Fatalf("history length: got %d want 3", len(entries))
+	}
+	if entries[0].Preview != "third" || entries[1].Kind != historyKindBinary || entries[2].Preview != "first" {
+		t.Fatalf("unexpected history order or metadata: %+v", entries)
+	}
+
+	rr := serveHistoryRequest(t, handler, http.MethodGet, "/", nil)
+	if got := rr.Body.String(); got != "third" {
+		t.Fatalf("latest body: got %q want %q", got, "third")
+	}
+
+	rr = serveHistoryRequest(t, handler, http.MethodGet, historyPath+"/"+entries[1].ID, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("history entry status: got %d want %d", rr.Code, http.StatusOK)
+	}
+	if !bytes.Equal(rr.Body.Bytes(), binary) {
+		t.Fatalf("binary body: got %v want %v", rr.Body.Bytes(), binary)
+	}
+}
+
+func TestHistoryMetadataPreviewKinds(t *testing.T) {
+	now := time.Date(2026, 4, 29, 10, 0, 0, 0, time.FixedZone("JST", 9*60*60))
+
+	text := newHistoryEntry("text", now, []byte("hello\n\tworld   "+strings.Repeat("x", 100)), false)
+	if text.Kind != historyKindText {
+		t.Fatalf("text kind: got %q want %q", text.Kind, historyKindText)
+	}
+	if strings.ContainsAny(text.Preview, "\n\t\r\x1b") {
+		t.Fatalf("text preview contains terminal-unsafe characters: %q", text.Preview)
+	}
+	if !strings.HasPrefix(text.Preview, "hello world ") || !strings.HasSuffix(text.Preview, "...") {
+		t.Fatalf("text preview: got %q", text.Preview)
+	}
+
+	control := newHistoryEntry("control", now, []byte("hello\x1b[31mred"), false)
+	if control.Kind != historyKindBinary {
+		t.Fatalf("control kind: got %q want %q", control.Kind, historyKindBinary)
+	}
+	if strings.Contains(control.Preview, "\x1b") || strings.Contains(control.Preview, "hello") {
+		t.Fatalf("control preview is not safe: %q", control.Preview)
+	}
+
+	imageEntry := newHistoryEntry("image", now, testPNG(t, 2, 3), false)
+	if imageEntry.Kind != historyKindImage || imageEntry.MIME != "image/png" || imageEntry.Preview != "PNG image 2x3" {
+		t.Fatalf("image metadata: got %+v", imageEntry)
+	}
+
+	binary := []byte{0x00, 0xff, 0x10, 0x20}
+	binaryEntry := newHistoryEntry("binary", now, binary, false)
+	if binaryEntry.Kind != historyKindBinary {
+		t.Fatalf("binary kind: got %q want %q", binaryEntry.Kind, historyKindBinary)
+	}
+	if binaryEntry.Preview != "binary sha256:"+shaPrefix(binary) {
+		t.Fatalf("binary preview: got %q", binaryEntry.Preview)
+	}
+
+	encrypted := newHistoryEntry("encrypted", now, []byte("secret plaintext"), true)
+	if encrypted.Kind != historyKindEncrypted {
+		t.Fatalf("encrypted kind: got %q want %q", encrypted.Kind, historyKindEncrypted)
+	}
+	if strings.Contains(encrypted.Preview, "secret") || encrypted.Preview != "encrypted sha256:"+shaPrefix([]byte("secret plaintext")) {
+		t.Fatalf("encrypted preview exposes data or has wrong hash: %q", encrypted.Preview)
+	}
+}
+
+func TestHistoryEncryptedServerEntryDoesNotExposePlaintext(t *testing.T) {
+	handler := newHistoryTestHandler(3, 0)
+	putClipboard(t, handler, []byte("secret plaintext"), true)
+
+	entries := getHistory(t, handler)
+	if len(entries) != 1 {
+		t.Fatalf("history length: got %d want 1", len(entries))
+	}
+	if entries[0].Kind != historyKindEncrypted {
+		t.Fatalf("encrypted kind: got %q want %q", entries[0].Kind, historyKindEncrypted)
+	}
+	if strings.Contains(entries[0].Preview, "secret") || entries[0].Preview != "encrypted sha256:"+shaPrefix([]byte("secret plaintext")) {
+		t.Fatalf("encrypted preview exposes data or has wrong hash: %q", entries[0].Preview)
+	}
+}
+
+func TestHistoryListExcludesExpiredEntries(t *testing.T) {
+	base := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	now := base
+	store := newHistoryStore(10, time.Second)
+	store.now = func() time.Time { return now }
+
+	item, err := store.Add([]byte("expired"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now = base.Add(2 * time.Second)
+
+	if entries := store.List(); len(entries) != 0 {
+		t.Fatalf("history length after expiration: got %d want 0", len(entries))
+	}
+	if _, ok := store.Get(item.ID); ok {
+		t.Fatalf("expired entry should not be pasteable")
+	}
+	if _, ok := store.Latest(); ok {
+		t.Fatalf("expired entry should not be latest")
+	}
+}
+
+func TestHistoryDeleteEntry(t *testing.T) {
+	handler := newHistoryTestHandler(3, 0)
+	putClipboard(t, handler, []byte("old"), false)
+	putClipboard(t, handler, []byte("new"), false)
+
+	entries := getHistory(t, handler)
+	rr := serveHistoryRequest(t, handler, http.MethodDelete, historyPath+"/"+entries[0].ID, nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete status: got %d want %d", rr.Code, http.StatusNoContent)
+	}
+
+	entries = getHistory(t, handler)
+	if len(entries) != 1 || entries[0].Preview != "old" || !entries[0].Latest {
+		t.Fatalf("history after delete: %+v", entries)
+	}
+	rr = serveHistoryRequest(t, handler, http.MethodGet, "/", nil)
+	if got := rr.Body.String(); got != "old" {
+		t.Fatalf("latest after delete: got %q want %q", got, "old")
+	}
+
+	rr = serveHistoryRequest(t, handler, http.MethodDelete, historyPath+"/missing", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("missing delete status: got %d want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestHistoryClear(t *testing.T) {
+	handler := newHistoryTestHandler(3, 0)
+	putClipboard(t, handler, []byte("old"), false)
+	putClipboard(t, handler, []byte("new"), false)
+
+	rr := serveHistoryRequest(t, handler, http.MethodDelete, historyPath, nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("clear status: got %d want %d", rr.Code, http.StatusNoContent)
+	}
+	if entries := getHistory(t, handler); len(entries) != 0 {
+		t.Fatalf("history length after clear: got %d want 0", len(entries))
+	}
+	rr = serveHistoryRequest(t, handler, http.MethodGet, "/", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("GET / after clear: got %d want %d", rr.Code, http.StatusNotFound)
+	}
+}
+
+func TestPasteRunnerPasteByID(t *testing.T) {
+	handler := newHistoryTestHandler(3, 0)
+	putClipboard(t, handler, []byte("first"), false)
+	putClipboard(t, handler, []byte("second"), false)
+	entries := getHistory(t, handler)
+
+	t.Setenv(pbgopyServerEnv, "http://pbgopy.test")
+
+	var stdout bytes.Buffer
+	r := &pasteRunner{
+		timeout:    time.Second,
+		maxBufSize: "500mb",
+		id:         entries[1].ID,
+		stdout:     &stdout,
+		client:     newHandlerClient(handler),
+	}
+	if err := r.run(nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if got := stdout.String(); got != "first" {
+		t.Fatalf("paste --id output: got %q want %q", got, "first")
+	}
+}
+
+func TestHistoryRunnerListJSON(t *testing.T) {
+	handler := newHistoryTestHandler(3, 0)
+	putClipboard(t, handler, []byte("first"), false)
+
+	t.Setenv(pbgopyServerEnv, "http://pbgopy.test")
+
+	var stdout bytes.Buffer
+	r := &historyRunner{
+		timeout:    time.Second,
+		jsonOutput: true,
+		stdout:     &stdout,
+		client:     newHandlerClient(handler),
+	}
+	if err := r.list(nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var entries []HistoryEntry
+	if err := json.Unmarshal(stdout.Bytes(), &entries); err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Preview != "first" || !entries[0].Latest {
+		t.Fatalf("json history output: %+v", entries)
+	}
+}
+
+func newHistoryTestHandler(limit int, ttl time.Duration) http.Handler {
+	r := &serveRunner{
+		cache:        memorycache.NewCache(),
+		historyLimit: limit,
+		ttl:          ttl,
+	}
+	return r.newServer().Handler
+}
+
+func putClipboard(t *testing.T, handler http.Handler, body []byte, encrypted bool) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+	if encrypted {
+		req.Header.Set(historyEncryptedHeader, "true")
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT / status: got %d want %d body %q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+}
+
+func getHistory(t *testing.T, handler http.Handler) []HistoryEntry {
+	t.Helper()
+	rr := serveHistoryRequest(t, handler, http.MethodGet, historyPath, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET /history status: got %d want %d body %q", rr.Code, http.StatusOK, rr.Body.String())
+	}
+	var entries []HistoryEntry
+	if err := json.Unmarshal(rr.Body.Bytes(), &entries); err != nil {
+		t.Fatal(err)
+	}
+	return entries
+}
+
+func serveHistoryRequest(t *testing.T, handler http.Handler, method, path string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body == nil {
+		reader = bytes.NewReader(nil)
+	} else {
+		reader = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, path, reader)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	return rr
+}
+
+func testPNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var b bytes.Buffer
+	if err := png.Encode(&b, img); err != nil {
+		t.Fatal(err)
+	}
+	return b.Bytes()
+}
+
+func shaPrefix(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])[:8]
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func newHandlerClient(handler http.Handler) *http.Client {
+	return &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			return rr.Result(), nil
+		}),
+	}
+}

--- a/commands/paste.go
+++ b/commands/paste.go
@@ -27,9 +27,11 @@ type pasteRunner struct {
 	gpgPath                string
 	basicAuth              string
 	maxBufSize             string
+	id                     string
 
 	stdout io.Writer
 	stderr io.Writer
+	client *http.Client
 }
 
 func NewPasteCommand(stdout, stderr io.Writer) *cobra.Command {
@@ -41,7 +43,8 @@ func NewPasteCommand(stdout, stderr io.Writer) *cobra.Command {
 		Use:   "paste",
 		Short: "Paste to stdout",
 		Example: `  export PBGOPY_SERVER=http://host.xz:9090
-  pbgopy paste >hello.txt`,
+  pbgopy paste >hello.txt
+  pbgopy paste --id <entry-id> >hello.txt`,
 		RunE: r.run,
 	}
 	cmd.Flags().DurationVar(&r.timeout, "timeout", 5*time.Second, "Time limit for requests")
@@ -53,6 +56,7 @@ func NewPasteCommand(stdout, stderr io.Writer) *cobra.Command {
 	cmd.Flags().StringVar(&r.privateKeyPasswordFile, "private-key-password-file", "", "Path to password file to decrypt the encrypted private key")
 	cmd.Flags().StringVarP(&r.basicAuth, "basic-auth", "a", "", "Basic authentication, username:password")
 	cmd.Flags().StringVar(&r.maxBufSize, "max-size", "500mb", "Max data size with unit")
+	cmd.Flags().StringVar(&r.id, "id", "", "History entry id to paste")
 	return cmd
 }
 
@@ -61,12 +65,14 @@ func (r *pasteRunner) run(_ *cobra.Command, _ []string) error {
 	if address == "" {
 		return fmt.Errorf("put the pbgopy server's address into %s environment variable", pbgopyServerEnv)
 	}
-	client := &http.Client{
-		Timeout: r.timeout,
-	}
+	client := r.httpClient()
 
 	// Start reading data.
-	req, err := http.NewRequest(http.MethodGet, address, nil)
+	reqURL := address
+	if r.id != "" {
+		reqURL = historyEntryURL(address, r.id)
+	}
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return fmt.Errorf("failed to make request: %w", err)
 	}
@@ -77,7 +83,7 @@ func (r *pasteRunner) run(_ *cobra.Command, _ []string) error {
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed request: Status %s", res.Status)
+		return failedRequestError(res)
 	}
 	sizeInBytes, err := datasizeToBytes(r.maxBufSize)
 	if err != nil {
@@ -94,8 +100,19 @@ func (r *pasteRunner) run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	fmt.Fprint(r.stdout, string(data))
+	if _, err := r.stdout.Write(data); err != nil {
+		return fmt.Errorf("failed to write to stdout: %w", err)
+	}
 	return nil
+}
+
+func (r *pasteRunner) httpClient() *http.Client {
+	if r.client != nil {
+		return r.client
+	}
+	return &http.Client{
+		Timeout: r.timeout,
+	}
 }
 
 // decrypts with the user-specified way. It directly gives back the given data if any key doesn't exists.

--- a/commands/serve.go
+++ b/commands/serve.go
@@ -124,7 +124,7 @@ func (r *serveRunner) handle(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case http.MethodGet:
 		if item, ok := r.history.Latest(); ok {
-			w.Write(item.body)
+			_, _ = w.Write(item.body)
 			return
 		}
 		if r.history.EverAdded() {
@@ -204,7 +204,7 @@ func (r *serveRunner) handleHistoryEntry(w http.ResponseWriter, req *http.Reques
 		if item.MIME != "" {
 			w.Header().Set("Content-Type", item.MIME)
 		}
-		w.Write(item.body)
+		_, _ = w.Write(item.body)
 	case http.MethodDelete:
 		if !r.history.Delete(id) {
 			http.Error(w, "The history entry not found", http.StatusNotFound)

--- a/commands/serve.go
+++ b/commands/serve.go
@@ -2,12 +2,14 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -17,24 +19,30 @@ import (
 )
 
 const (
-	defaultPort = 9090
-	defaultTTL  = time.Hour * 24
+	defaultPort         = 9090
+	defaultTTL          = time.Hour * 24
+	defaultHistoryLimit = 1
 
 	rootPath        = "/"
 	lastUpdatedPath = "/lastupdated"
+	historyPath     = "/history"
 
 	dataCacheKey        = "data"
 	lastUpdatedCacheKey = "lastUpdated"
+
+	historyEncryptedHeader = "X-Pbgopy-Encrypted"
 )
 
 type serveRunner struct {
-	port      int
-	ttl       time.Duration
-	basicAuth string
+	port         int
+	ttl          time.Duration
+	historyLimit int
+	basicAuth    string
 
-	cache  cache.Cache
-	stdout io.Writer
-	stderr io.Writer
+	cache   cache.Cache
+	history *historyStore
+	stdout  io.Writer
+	stderr  io.Writer
 }
 
 func NewServeCommand(stdout, stderr io.Writer) *cobra.Command {
@@ -46,17 +54,21 @@ func NewServeCommand(stdout, stderr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "serve",
 		Short:   "Start the server that acts like a clipboard",
-		Example: "pbgopy serve --port=9090 --ttl=10m",
+		Example: "pbgopy serve --port=9090 --ttl=10m --history-limit=20",
 		RunE:    r.run,
 	}
 
 	cmd.Flags().IntVarP(&r.port, "port", "p", defaultPort, "The port the server listens on")
 	cmd.Flags().DurationVar(&r.ttl, "ttl", defaultTTL, "The time that the contents is stored. Give 0s for disabling TTL")
+	cmd.Flags().IntVar(&r.historyLimit, "history-limit", defaultHistoryLimit, "Number of clipboard entries to retain. Give 0 for unlimited history")
 	cmd.Flags().StringVarP(&r.basicAuth, "basic-auth", "a", "", "Basic authentication, username:password")
 	return cmd
 }
 
 func (r *serveRunner) run(_ *cobra.Command, _ []string) error {
+	if r.historyLimit < 0 {
+		return fmt.Errorf("history-limit must be greater than or equal to 0")
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	if r.ttl == 0 {
@@ -64,6 +76,7 @@ func (r *serveRunner) run(_ *cobra.Command, _ []string) error {
 	} else {
 		r.cache = memorycache.NewTTLCache(ctx, r.ttl, r.ttl)
 	}
+	r.history = newHistoryStore(r.historyLimit, r.ttl)
 
 	server := r.newServer()
 	defer func() {
@@ -81,19 +94,43 @@ func (r *serveRunner) run(_ *cobra.Command, _ []string) error {
 }
 
 func (r *serveRunner) newServer() *http.Server {
+	r.ensureCache()
+	r.ensureHistoryStore()
 	mux := http.NewServeMux()
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", r.port),
 		Handler: mux,
 	}
+	mux.HandleFunc(historyPath, r.basicAuthHandler(r.handleHistory))
+	mux.HandleFunc(historyPath+"/", r.basicAuthHandler(r.handleHistoryEntry))
 	mux.HandleFunc(rootPath, r.basicAuthHandler(r.handle))
 	mux.HandleFunc(lastUpdatedPath, r.basicAuthHandler(r.handleLastUpdated))
 	return server
 }
 
+func (r *serveRunner) ensureCache() {
+	if r.cache == nil {
+		r.cache = memorycache.NewCache()
+	}
+}
+
+func (r *serveRunner) ensureHistoryStore() {
+	if r.history == nil {
+		r.history = newHistoryStore(r.historyLimit, r.ttl)
+	}
+}
+
 func (r *serveRunner) handle(w http.ResponseWriter, req *http.Request) {
 	switch req.Method {
 	case http.MethodGet:
+		if item, ok := r.history.Latest(); ok {
+			w.Write(item.body)
+			return
+		}
+		if r.history.EverAdded() {
+			http.Error(w, "The data not found", http.StatusNotFound)
+			return
+		}
 		data, err := r.cache.Get(dataCacheKey)
 		if errors.Is(err, cache.ErrNotFound) {
 			http.Error(w, "The data not found", http.StatusNotFound)
@@ -114,6 +151,11 @@ func (r *serveRunner) handle(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "Bad request body", http.StatusBadRequest)
 			return
 		}
+		encrypted := req.Header.Get(historyEncryptedHeader) == "true"
+		if _, err := r.history.Add(body, encrypted); err != nil {
+			http.Error(w, fmt.Sprintf("Failed to save history: %v", err), http.StatusInternalServerError)
+			return
+		}
 		if err := r.cache.Put(dataCacheKey, body); err != nil {
 			http.Error(w, fmt.Sprintf("Failed to cache: %v", err), http.StatusInternalServerError)
 			return
@@ -123,6 +165,57 @@ func (r *serveRunner) handle(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
+	default:
+		http.Error(w, fmt.Sprintf("Method %s is not allowed", req.Method), http.StatusMethodNotAllowed)
+	}
+}
+
+func (r *serveRunner) handleHistory(w http.ResponseWriter, req *http.Request) {
+	switch req.Method {
+	case http.MethodGet:
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(r.history.List()); err != nil {
+			http.Error(w, "Failed to encode history", http.StatusInternalServerError)
+			return
+		}
+	case http.MethodDelete:
+		r.history.Clear()
+		_ = r.cache.Delete(dataCacheKey)
+		w.WriteHeader(http.StatusNoContent)
+	default:
+		http.Error(w, fmt.Sprintf("Method %s is not allowed", req.Method), http.StatusMethodNotAllowed)
+	}
+}
+
+func (r *serveRunner) handleHistoryEntry(w http.ResponseWriter, req *http.Request) {
+	id := strings.TrimPrefix(req.URL.Path, historyPath+"/")
+	if id == "" || strings.Contains(id, "/") {
+		http.Error(w, "The history entry id is invalid", http.StatusBadRequest)
+		return
+	}
+
+	switch req.Method {
+	case http.MethodGet:
+		item, ok := r.history.Get(id)
+		if !ok {
+			http.Error(w, "The history entry not found", http.StatusNotFound)
+			return
+		}
+		if item.MIME != "" {
+			w.Header().Set("Content-Type", item.MIME)
+		}
+		w.Write(item.body)
+	case http.MethodDelete:
+		if !r.history.Delete(id) {
+			http.Error(w, "The history entry not found", http.StatusNotFound)
+			return
+		}
+		if item, ok := r.history.Latest(); ok {
+			_ = r.cache.Put(dataCacheKey, item.body)
+		} else {
+			_ = r.cache.Delete(dataCacheKey)
+		}
+		w.WriteHeader(http.StatusNoContent)
 	default:
 		http.Error(w, fmt.Sprintf("Method %s is not allowed", req.Method), http.StatusMethodNotAllowed)
 	}

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func main() {
 	a.addCommands(
 		commands.NewCopyCommand(a.stdout, a.stderr),
 		commands.NewPasteCommand(a.stdout, a.stderr),
+		commands.NewHistoryCommand(a.stdout, a.stderr),
 		commands.NewServeCommand(a.stdout, a.stderr),
 		commands.NewVersionCommand(a.stderr),
 	)


### PR DESCRIPTION
Close https://github.com/nakabonne/pbgopy/issues/34

## Why

pbgopy only retained the latest clipboard value, which made it difficult to recover or reuse earlier copied content across devices.

## What

Adds opt-in clipboard history with listing, metadata, targeted paste, and deletion while keeping the existing latest-only workflow as the default.
