### PR TITLE
Prepare release workflow for v0.4.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,19 +8,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-      - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/checkout@v4
         with:
-          go-version: 1.15
+          fetch-depth: 0
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
       - name: Login docker.io
-        run: docker login -u nakabonne -p ${{ secrets.DOCKER_PASSWORD }}
+        uses: docker/login-action@v3
+        with:
+          username: nakabonne
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN_WITH_REPO_PERM }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,10 @@
+version: 2
 before:
   hooks:
     - go mod tidy
 builds:
-- main: .
+- id: pbgopy
+  main: .
   binary: pbgopy
   goos:
     - freebsd
@@ -21,22 +23,30 @@ builds:
   goarm:
     - 6
     - 7
+  ignore:
+    - goos: windows
+      goarch: arm
   env:
     - CGO_ENABLED=0
   ldflags: -s -w -X github.com/nakabonne/pbgopy/commands.version={{.Version}} -X github.com/nakabonne/pbgopy/commands.commit={{.ShortCommit}} -X github.com/nakabonne/pbgopy/commands.date={{.Date}}
 
 archives:
-- replacements:
-    386: 32-bit
+- name_template: >-
+    {{ .ProjectName }}_
+    {{- .Version }}_
+    {{- .Os }}_
+    {{- if eq .Arch "386" }}32-bit
+    {{- else }}{{ .Arch }}{{ end }}
+    {{- with .Arm }}v{{ . }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Version }}-next"
 
 brews:
-  - tap:
+  - repository:
       owner: nakabonne
       name: homebrew-pbgopy
     homepage: "https://github.com/nakabonne/pbgopy"
@@ -51,11 +61,13 @@ nfpms:
       - rpm
       - deb
 
-dockers:
+dockers_v2:
   - dockerfile: Dockerfile
-    binaries:
+    ids:
       - pbgopy
-    image_templates:
-      - "nakabonne/pbgopy:latest"
-      - "nakabonne/pbgopy:{{ .Tag }}"
-      - "nakabonne/pbgopy:v{{ .Major }}.{{ .Minor }}"
+    images:
+      - "nakabonne/pbgopy"
+    tags:
+      - "latest"
+      - "{{ .Tag }}"
+      - "v{{ .Major }}.{{ .Minor }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine
 
-COPY pbgopy /usr/bin/
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/pbgopy /usr/bin/
 CMD ["pbgopy"]

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ brew install nakabonne/pbgopy/pbgopy
 #### RHEL/CentOS
 
 ```
-rpm -ivh https://github.com/nakabonne/pbgopy/releases/download/v0.3.0/pbgopy_0.3.0_linux_amd64.rpm
+rpm -ivh https://github.com/nakabonne/pbgopy/releases/download/v0.4.0/pbgopy_0.4.0_linux_amd64.rpm
 ```
 
 #### Debian/Ubuntu
 
 ```
-wget https://github.com/nakabonne/pbgopy/releases/download/v0.3.0/pbgopy_0.3.0_linux_amd64.deb
-apt install ./pbgopy_0.3.0_linux_amd64.deb
+wget https://github.com/nakabonne/pbgopy/releases/download/v0.4.0/pbgopy_0.4.0_linux_amd64.deb
+apt install ./pbgopy_0.4.0_linux_amd64.deb
 ```
 
 #### Arch Linux


### PR DESCRIPTION
## What changed

- Updated the release workflow to current GitHub Actions, Go 1.21, Docker login action, and GoReleaser action syntax.
- Migrated the GoReleaser config to version 2, including archive naming, snapshot versioning, Docker v2 config, and the unsupported Windows ARM target exclusion.
- Updated README rpm/deb installation examples from v0.3.0 to v0.4.0.

## Why

The v0.4.0 release should run on a Go version compatible with go.mod and a GoReleaser configuration accepted by current GoReleaser releases.

## Validation

- goreleaser check
- GOCACHE=/Users/nakabonne/src/github.com/nakabonne/pbgopy/.gocache go test ./...
- GOCACHE=/Users/nakabonne/src/github.com/nakabonne/pbgopy/.gocache go test -race ./...
- GOCACHE=/Users/nakabonne/src/github.com/nakabonne/pbgopy/.gocache goreleaser release --snapshot --clean --skip=publish,docker

Note: GoReleaser still warns that brews is being phased out in favor of homebrew_casks; this PR keeps brews intentionally so the existing Homebrew formula install path continues to work.