### PR TITLE
Disable Docker SBOM attestation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -71,3 +71,4 @@ dockers_v2:
       - "latest"
       - "{{ .Tag }}"
       - "v{{ .Major }}.{{ .Minor }}"
+    sbom: false


### PR DESCRIPTION
## What changed

- Set `sbom: false` on the GoReleaser `dockers_v2` configuration.

## Why

The `v0.4.0` release workflow failed while publishing Docker images because GoReleaser invoked `docker buildx build --attest=type=sbom`, and the GitHub Actions Docker driver reported that attestation is not supported.

Disabling Docker SBOM attestation keeps the release behavior focused on building and pushing the images without requiring a different Buildx driver or containerd image store setup.

## Validation

- `goreleaser check`
- `GOCACHE=/Users/nakabonne/src/github.com/nakabonne/pbgopy/.gocache goreleaser release --snapshot --clean --skip=publish`

The Docker-inclusive snapshot build completed successfully after the change.