### PR TITLE
Set up Buildx for release Docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Login docker.io
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## What changed

- Added `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` to the release workflow before Docker login and GoReleaser.

## Why

The `v0.4.0` release workflow now reaches Docker publishing, but GoReleaser invokes a multi-platform `docker buildx build --platform linux/amd64,linux/arm64 --push`. The default GitHub runner Docker driver does not support that multi-platform push path:

```text
ERROR: failed to build: Multi-platform build is not supported for the docker driver.
```

Setting up QEMU and Buildx gives the workflow a Buildx builder suitable for multi-platform Docker image publishing.

## Validation

- `goreleaser check`
- `GOCACHE=/Users/nakabonne/src/github.com/nakabonne/pbgopy/.gocache goreleaser release --snapshot --clean --skip=publish`

The local snapshot confirms the GoReleaser configuration still builds successfully. The exact failing path is GitHub Actions-specific because it depends on the runner's Buildx driver.